### PR TITLE
Use an .npmrc to prevent creating a package-lock on each install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
For this we first need to have #79 fixed and run prettier again.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>