### PR TITLE
Add the missing `method` on the post method

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -996,6 +996,7 @@ abstract class PinejsClientCoreTemplate<
 			deprecated.postStringParams();
 			params = { url: params };
 		}
+		params.method = 'POST';
 		return this.request(params);
 	}
 


### PR DESCRIPTION
Fixes a regression of v5.6.7.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>