### PR TITLE
🐛: Fix missing `deprecated.getStringParams` function

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -25,6 +25,7 @@ for (const method of [
 	'subscribe',
 	'compile',
 	'request',
+	'get',
 	'put',
 	'post',
 	'patch',


### PR DESCRIPTION
The function `deprecated.getStringParams` was used, but
not defined.

Change-type: patch
Signed-off-by: Andreas Fitzek <andreas@balena.io>